### PR TITLE
Revert to proper installation path of manual pages

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ BIN_PATH    = $(PREFIX)/bin
 HELPER_PATH = $(PREFIX)/lib/afl
 DOC_PATH    = $(PREFIX)/share/doc/afl
 MISC_PATH   = $(PREFIX)/share/afl
-MAN_PATH    = $(PREFIX)/man/man8
+MAN_PATH    = $(PREFIX)/share/man/man8
 
 PROGNAME    = afl
 VERSION     = $(shell grep '^$(HASH)define VERSION ' ../config.h | cut -d '"' -f2)


### PR DESCRIPTION
`MAN_PATH` changed in #529 has been overwritten in 4b3ad5f which may cause issues with packaging.